### PR TITLE
FAT2-344 location name bug

### DIFF
--- a/src/SFA.DAS.Location.Application/LocationImport/Services/LocationImportService.cs
+++ b/src/SFA.DAS.Location.Application/LocationImport/Services/LocationImportService.cs
@@ -51,8 +51,9 @@ namespace SFA.DAS.Location.Application.LocationImport.Services
                 .ToList()
                 .Where(item=>!string.IsNullOrEmpty(item.Attributes.LocationName))
                 .Where(item=>!string.IsNullOrEmpty(item.Attributes.LocalAuthorityName))
+                .Where(item=>!string.IsNullOrEmpty(item.Attributes.LocationAuthorityDistrict))
                 .Where(item => item.Attributes.PlaceName != PlaceNameDescription.None).ToList()
-                .GroupBy(c=>new {c.Attributes.LocalAuthorityName, c.Attributes.LocationName})
+                .GroupBy(c=>new {c.Attributes.LocalAuthorityName, c.Attributes.LocationName, c.Attributes.LocationAuthorityDistrict})
                 .Select(item => item.First())
                 .GroupBy(c => new {c.Attributes.Id})
                 .Select(SelectDuplicateByLocalAuthorityDistrictDescription)
@@ -78,7 +79,14 @@ namespace SFA.DAS.Location.Application.LocationImport.Services
             
             if (values.Count > 1)
             {
-                return values.OrderByDescending(c=>c.Attributes.LocalAuthorityDistrict)
+                var orderByDescending = values.OrderByDescending(c=>c.Attributes.LocalAuthorityDistrict).ToList();
+                var locationApiItem = orderByDescending.FirstOrDefault(c => !string.IsNullOrEmpty(c.Attributes.LocalAuthorityDistrictDescription) 
+                                                                            && c.Attributes.LocationName.Equals(c.Attributes.LocationAuthorityDistrict, StringComparison.CurrentCultureIgnoreCase));
+                if(locationApiItem != null)
+                {
+                    return locationApiItem;
+                }
+                return orderByDescending
                     .FirstOrDefault(c => !string.IsNullOrEmpty(c.Attributes.LocalAuthorityDistrictDescription));
             }
             

--- a/src/SFA.DAS.Location.Domain.UnitTests/Entities/WhenMappingLocationApiItemToLocationImport.cs
+++ b/src/SFA.DAS.Location.Domain.UnitTests/Entities/WhenMappingLocationApiItemToLocationImport.cs
@@ -18,6 +18,7 @@ namespace SFA.DAS.Location.Domain.UnitTests.Entities
                 .Excluding(c=>c.PlaceName)
                 .Excluding(c=>c.LocalAuthorityDistrictDescription)
                 .Excluding(c=>c.LocalAuthorityDistrict)
+                .Excluding(c=>c.LocationAuthorityDistrict)
             );
         }
     }

--- a/src/SFA.DAS.Location.Domain/ImportTypes/OnsLocationApiResponse.cs
+++ b/src/SFA.DAS.Location.Domain/ImportTypes/OnsLocationApiResponse.cs
@@ -43,7 +43,10 @@ namespace SFA.DAS.Location.Domain.ImportTypes
 
         [JsonProperty("laddescnm")] 
         public string LocalAuthorityDistrictDescription { get; set; }
-
+        
+        [JsonProperty("lad15nm")]
+        public string LocationAuthorityDistrict { get; set; }
+        
         [JsonIgnore]
         public PlaceNameDescription PlaceName => MapDescription<PlaceNameDescription>(PlaceNameDescription);
 


### PR DESCRIPTION
When we have multiple location items with the same Id, do an additional check to see if the place name matches the location authority district for city names etc. If it matches then it is used, if not then it picks the first as before